### PR TITLE
Add support for pg_trgm in pglite driver

### DIFF
--- a/.changeset/cool-dogs-agree.md
+++ b/.changeset/cool-dogs-agree.md
@@ -1,0 +1,5 @@
+---
+"farstorm": minor
+---
+
+Add pg_trgm support when using pglite driver

--- a/src/drivers/pglite.ts
+++ b/src/drivers/pglite.ts
@@ -1,8 +1,8 @@
 import { Driver, TransactionControls } from './Driver.js';
 import EventEmitter from '../helpers/MyEventEmitter.js';
 import { PGlite, types } from '@electric-sql/pglite';
-// @ts-ignore
 import { fuzzystrmatch } from '@electric-sql/pglite/contrib/fuzzystrmatch';
+import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm';
 
 export type ConnectionDetails = {
 	type: 'pglite',
@@ -20,6 +20,7 @@ export class PgLiteDriver extends EventEmitter implements Driver {
 			loadDataDir: connectionDetails.file,
 			extensions: {
 				fuzzystrmatch,
+				pg_trgm,
 			},
 			parsers: {
 				[types.NUMERIC]: (value) => parseFloat(value),

--- a/tests/pglite-backend/extensions.test.ts
+++ b/tests/pglite-backend/extensions.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from "vitest";
+import { Farstorm, sql } from "../../src/main";
+
+describe('PGLite: extensions', () => {
+	async function setup() {
+		const db = new Farstorm({
+			type: 'pglite',
+		}, {});
+
+		return {
+			db,
+			cleanup: async () => {
+				await db.inTransaction(async ({ nativeQuery }) => {
+					await nativeQuery(sql`rollback;`);
+				});
+			},
+		};
+	}
+
+	it('creating extension pg_trgm should work', async ({ expect }) => {
+		const { db, cleanup } = await setup();
+		try {
+			await db.inTransaction(async ({ nativeQuery }) => {
+				await nativeQuery(sql`create extension if not exists pg_trgm;`);
+			});
+		} catch (e) {
+			expect.fail('Should not throw exception');
+		}
+		await cleanup();
+	});
+});


### PR DESCRIPTION
Fixes #3 

This is definitely not ideal, I think we should probably move to a system where we let the consumer of the library inject either a pglite instance, or a pg instance instead of defining these as hard dependencies. That way we prevent this same type of problem in the future for other types of extensions. I've opened up #2 to track that.